### PR TITLE
Add console parameter to printFailedTests function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ const qunitArgs = {
 
 runQunitPuppeteer(qunitArgs)
   .then((result) => {
-    printResultSummary(result);
+    printResultSummary(result, console);
 
     if (result.stats.failed > 0) {
-      printFailedTests(result);
+      printFailedTests(result, console);
     }
   })
   .catch((ex) => {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const qunitArgs = {
   // (optional, 30000 by default) global timeout for the tests suite
   timeout: 10000,
   // (optional, false by default) should the browser console be redirected or not
-  redirectConsole: true,
+  redirectConsole: true
 };
 
 runQunitPuppeteer(qunitArgs)
@@ -68,7 +68,7 @@ const qunitArgs = {
   // (optional, 30000 by default) global timeout for the tests suite
   timeout: 10000,
   // (optional, false by default) should the browser console be redirected or not
-  redirectConsole: true,
+  redirectConsole: true
 };
 
 runQunitPuppeteer(qunitArgs)

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ function printResultSummary(result, console) {
  * Takes the output of runQunitPuppeteer and prints failed test(s) information to console with identation and colors
  * @param {*} result result of the runQunitPuppeteer
  */
-function printFailedTests(result) {
+function printFailedTests(result, console) {
   // there is nothing to see here . . . move along, move along
   if (result.stats.failed === 0) {
     return;

--- a/index.js
+++ b/index.js
@@ -238,25 +238,14 @@ async function runQunitPuppeteer(qunitPuppeteerArgs) {
  * @param {*} result result of the runQunitPuppeteer
  */
 function printOutput(result, console) {
-  if (result.stats.failed === 0) {
-    console.log('Test run result: success'.green.bold);
-  } else {
-    console.log('Test run result: fail'.red.bold);
-  }
-
-  console.group(`Total tests: ${result.totalTests}`);
-  console.log(`Assertions: ${result.stats.total}`);
-  console.log(`Passed assertions: ${result.stats.passed.toString().green}`);
-  console.log(`Failed assertions: ${result.stats.failed > 0 ? result.stats.failed.toString().red : result.stats.failed}`);
-  console.log(`Elapsed: ${result.stats.runtime}ms`);
-  console.groupEnd();
-
   const moduleNames = Object.keys(result.modules);
-  for (let i = 0; i < moduleNames.length; i += 1) {
+  const moduleCount = moduleNames.length;
+  for (let i = 0; i < moduleCount; i += 1) {
     const module = result.modules[moduleNames[i]];
     console.group(`Module: ${module.name}`);
 
-    for (let j = 0; j < module.tests.length; j += 1) {
+    const testCount = module.tests.length;
+    for (let j = 0; j < testCount; j += 1) {
       const test = module.tests[j];
       console.group(`${test.name}`);
       if (test.failed > 0) {
@@ -269,13 +258,7 @@ function printOutput(result, console) {
 
       if (test.failed > 0) {
         if (test.log) {
-          console.group('Log');
-          for (let n = 0; n < test.log.length; n += 1) {
-            const logRecord = test.log[n];
-            const message = `Result: ${logRecord.result}, Expected: ${logRecord.expected}, Actual: ${logRecord.actual}, Message: ${logRecord.message}`;
-            console.log(logRecord.result ? message.green : message.red);
-          }
-          console.groupEnd();
+          printTestLog(test.log, console);
         }
       }
 
@@ -284,6 +267,8 @@ function printOutput(result, console) {
 
     console.groupEnd();
   }
+
+  printResultSummary(result, console);
 }
 
 
@@ -319,9 +304,7 @@ function printFailedTests(result, console) {
     return;
   }
 
-  // Why is "result.modules" an object instead of an array?
   const moduleNames = Object.keys(result.modules);
-
   const moduleCount = moduleNames.length;
   for (let i = 0; i < moduleCount; i += 1) {
     const module = result.modules[moduleNames[i]];
@@ -349,16 +332,7 @@ function printFailedTests(result, console) {
       console.log(`Elapsed: ${test.runtime}ms`);
 
       if (test.log) {
-        console.group('Log');
-
-        const logCount = test.log.length;
-        for (let n = 0; n < logCount; n += 1) {
-          const logRecord = test.log[n];
-          const message = `Result: ${logRecord.result}, Expected: ${logRecord.expected}, Actual: ${logRecord.actual}, Message: ${logRecord.message}`;
-          console.log(logRecord.result ? message.green : message.red);
-        }
-
-        console.groupEnd();
+        printTestLog(test.log, console);
       }
 
       console.groupEnd();
@@ -366,6 +340,23 @@ function printFailedTests(result, console) {
 
     console.groupEnd();
   }
+}
+
+/**
+ * Takes the test's log output and prints the information to console with identation and colors
+ * @param {*} log log of the test
+ */
+function printTestLog(log, console) {
+  console.group('Log');
+
+  const logCount = log.length;
+  for (let n = 0; n < logCount; n += 1) {
+    const logRecord = log[n];
+    const message = `Result: ${logRecord.result}, Expected: ${logRecord.expected}, Actual: ${logRecord.actual}, Message: ${logRecord.message}`;
+    console.log(logRecord.result ? message.green : message.red);
+  }
+
+  console.groupEnd();
 }
 
 module.exports.runQunitPuppeteer = runQunitPuppeteer;

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,18 +1,26 @@
 const path = require('path');
-const { runQunitPuppeteer, printOutput } = require('../index');
+const { runQunitPuppeteer, printOutput, printResultSummary, printFailedTests } = require('../index');
 
 const qunitArgs = {
   targetUrl: `file://${path.join(__dirname, 'test-runner.html')}`,
   timeout: 10000,
-  redirectConsole: true,
+  redirectConsole: true
 };
 
 runQunitPuppeteer(qunitArgs)
   .then((result) => {
     // Print the test result to the output
+    console.log();
+    console.log('==========    printOutput     =========='.blue.bold);
     printOutput(result, console);
+
+    console.log();
+    console.log('========== printResultSummary =========='.blue.bold);
+    printResultSummary(result, console);
     if (result.stats.failed > 0) {
-      // Handle the failed test run
+      console.log();
+      console.log('==========  printFailedTests  =========='.blue.bold);
+      printFailedTests(result, console);
     }
   })
   .catch((ex) => {


### PR DESCRIPTION
Oversight.  My apologies.  Also updated README to match.

Also considered calling `printResultSummary` from `printOutput` in order to reduce redundancy.  Let me know if you want that.