### PR TITLE
Fix #6 - Reformat the README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,27 @@ npm install -g node-qunit-puppeteer
 node-qunit-puppeteer <URL> [<timeout>] [<puppeteerArgs>]
 ```
 
-* `<URL>` - the address (or filepath) of the qunit test page.
+* `<URL>` - the address (or filepath) of the qunit HTML test page.
 * `<timeout>` - (optional) test run timeout in milliseconds. Default is 30000.
 * `<puppeteerArgs>` - (optional) Chrome command-line arguments. Default is "--allow-file-access-from-files".
 
-**Example:**
+#### Examples
 `node-qunit-puppeteer https://example.org/ 10000 "--allow-file-access-from-files --no-sandbox"`
+`node-qunit-puppeteer ./test/test-runner.html 10000 "--allow-file-access-from-files --no-sandbox"`
 
 ### Node module
 
 * npm: `npm install node-qunit-puppeteer --save-dev`
 * yarn: `yarn add node-qunit-puppeteer --dev`
 
-### Exported functions
+#### Exported functions
 
 * `async function runQunitPuppeteer(qunitPuppeteerArgs)` --  Opens the specified HTML page in a Chromium puppeteer and captures results of a test run. Returns an object with information on every module/test run.
 * `function printOutput(qunitResult, console)` -- Takes the output of runQunitPuppeteer and prints it to console with identation and colors.
 * `function printResultSummary(qunitResult, console)` -- Takes the output of runQunitPuppeteer and prints a summary to console with identation and colors.
 * `function printFailedTests(qunitResult, console)` -- Takes the output of runQunitPuppeteer and prints failed test(s) information to console with identation and colors.
 
-### Examples
+#### Examples
 
 ```javascript
 const path = require('path');
@@ -83,6 +84,7 @@ runQunitPuppeteer(qunitArgs)
 
     if (result.stats.failed > 0) {
       printFailedTests(result, console);
+	  // other action(s) on failed tests
     }
   })
   .catch((ex) => {
@@ -90,13 +92,11 @@ runQunitPuppeteer(qunitArgs)
   });
 ```
 
-### Output
-
-Here's what is printed to the output:
+## Output
 
 <img width="499" style="border: 1px solid #efefef" src="https://user-images.githubusercontent.com/5947035/47224776-0888c800-d3c5-11e8-9364-6d6f1d4b3bd1.png">
 
-Here's how the `result` object looks like:
+## `result` object
 ```json
 {
   "modules": {


### PR DESCRIPTION
How does the reformatted README look?

Perhaps the `output` image should be replaced as well.
![image](https://user-images.githubusercontent.com/17734739/54067634-47060e80-4210-11e9-898a-0551614a2854.png)

Maybe even separate ones for `Command-line` versus `Node module` examples.
![image](https://user-images.githubusercontent.com/17734739/54067686-dd3a3480-4210-11e9-9743-4a1bb737815c.png)
