### PR TITLE
Add stacktrace option to printFailedTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ runQunitPuppeteer(qunitArgs)
     printOutput(result, console);
     if (result.stats.failed > 0) {
       // Handle the failed test run
+      // e.g: Print failed tests without stacktrace
+      printFailedTests(result, console);
     }
   })
   .catch((ex) => {
@@ -83,7 +85,8 @@ runQunitPuppeteer(qunitArgs)
     printResultSummary(result, console);
 
     if (result.stats.failed > 0) {
-      printFailedTests(result, console);
+      // Print failed tests with stacktrace
+      printFailedTests(result, console, true);
 	  // other action(s) on failed tests
     }
   })

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ runQunitPuppeteer(qunitArgs)
     printOutput(result, console);
     if (result.stats.failed > 0) {
       // Handle the failed test run
-      // e.g: Print failed tests without stacktrace
-      printFailedTests(result, console);
     }
   })
   .catch((ex) => {
@@ -85,8 +83,7 @@ runQunitPuppeteer(qunitArgs)
     printResultSummary(result, console);
 
     if (result.stats.failed > 0) {
-      // Print failed tests with stacktrace
-      printFailedTests(result, console, true);
+      printFailedTests(result, console);
 	  // other action(s) on failed tests
     }
   })

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ async function runQunitPuppeteer(qunitPuppeteerArgs) {
 }
 
 /**
- * Takes the output of runQunitPuppeteer and prints it to console with identation and colors
+ * Takes the output of runQunitPuppeteer and prints it to console with indentation and colors
  * @param {*} result result of the runQunitPuppeteer
  */
 function printOutput(result, console) {
@@ -275,7 +275,7 @@ function printOutput(result, console) {
 
 
 /**
- * Takes the output of runQunitPuppeteer and prints a summary to console with identation and colors
+ * Takes the output of runQunitPuppeteer and prints a summary to console with indentation and colors
  * @param {*} result result of the runQunitPuppeteer
  */
 function printResultSummary(result, console) {
@@ -297,10 +297,10 @@ function printResultSummary(result, console) {
 
 
 /**
- * Takes the output of runQunitPuppeteer and prints failed test(s) information to console with identation and colors
+ * Takes the output of runQunitPuppeteer and prints failed test(s) information to console with indentation and colors
  * @param {*} result result of the runQunitPuppeteer
  */
-function printFailedTests(result, console, showStacktrace) {
+function printFailedTests(result, console) {
   // there is nothing to see here . . . move along, move along
   if (result.stats.failed === 0) {
     return;
@@ -334,7 +334,7 @@ function printFailedTests(result, console, showStacktrace) {
       console.log(`Elapsed: ${test.runtime}ms`);
 
       if (test.log) {
-        printTestLog(test.log, console, showStacktrace);
+        printTestLog(test.log, console);
       }
 
       console.groupEnd();
@@ -345,10 +345,10 @@ function printFailedTests(result, console, showStacktrace) {
 }
 
 /**
- * Takes the test's log output and prints the information to console with identation and colors
+ * Takes the test's log output and prints the information to console with indentation and colors
  * @param {*} log log of the test
  */
-function printTestLog(log, console, showStacktrace = false) {
+function printTestLog(log, console) {
   console.group('Log');
 
   const logCount = log.length;
@@ -356,7 +356,7 @@ function printTestLog(log, console, showStacktrace = false) {
     const logRecord = log[n];
     const message = `Result: ${logRecord.result}, Expected: ${logRecord.expected}, Actual: ${logRecord.actual}, Message: ${logRecord.message}`;
     console.log(logRecord.result ? message.green : message.red);
-    if (!logRecord.result && showStacktrace) {
+    if (!logRecord.result) {
       console.log(`Stacktrace: ${logRecord.source.trim()}`.dim);
     }
   }

--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ function printResultSummary(result, console) {
  * Takes the output of runQunitPuppeteer and prints failed test(s) information to console with identation and colors
  * @param {*} result result of the runQunitPuppeteer
  */
-function printFailedTests(result, console) {
+function printFailedTests(result, console, showStacktrace) {
   // there is nothing to see here . . . move along, move along
   if (result.stats.failed === 0) {
     return;
@@ -316,7 +316,7 @@ function printFailedTests(result, console) {
       continue;
     }
 
-    //console.log();
+    // console.log();
     console.group(`Module: ${module.name}`);
 
     const testCount = module.tests.length;
@@ -334,7 +334,7 @@ function printFailedTests(result, console) {
       console.log(`Elapsed: ${test.runtime}ms`);
 
       if (test.log) {
-        printTestLog(test.log, console);
+        printTestLog(test.log, console, showStacktrace);
       }
 
       console.groupEnd();
@@ -348,7 +348,7 @@ function printFailedTests(result, console) {
  * Takes the test's log output and prints the information to console with identation and colors
  * @param {*} log log of the test
  */
-function printTestLog(log, console) {
+function printTestLog(log, console, showStacktrace = false) {
   console.group('Log');
 
   const logCount = log.length;
@@ -356,6 +356,9 @@ function printTestLog(log, console) {
     const logRecord = log[n];
     const message = `Result: ${logRecord.result}, Expected: ${logRecord.expected}, Actual: ${logRecord.actual}, Message: ${logRecord.message}`;
     console.log(logRecord.result ? message.green : message.red);
+    if (!logRecord.result && showStacktrace) {
+      console.log(`Stacktrace: ${logRecord.source.trim()}`.dim);
+    }
   }
 
   console.groupEnd();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-qunit-puppeteer",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "A simple node module for running qunit tests with headless Chromium",
     "repository": {
         "type": "git",
@@ -11,7 +11,9 @@
     },
     "main": "index.js",
     "scripts": {
-        "test": "node test/test-runner.js"
+        "test": "node test/test-runner.js",
+        "lint": "eslint index.js cli.js test/**/*.js",
+        "lint:fix": "eslint index.js cli.js test/**/*.js --fix"
     },
     "dependencies": {
         "colors": "^1.3.2",

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,5 +1,7 @@
 const path = require('path');
-const { runQunitPuppeteer, printOutput, printResultSummary, printFailedTests } = require('../index');
+const {
+  runQunitPuppeteer, printOutput, printResultSummary, printFailedTests,
+} = require('../index');
 
 const qunitArgs = {
   targetUrl: `file://${path.join(__dirname, 'test-runner.html')}`,
@@ -21,6 +23,9 @@ runQunitPuppeteer(qunitArgs)
       console.log();
       console.log('==========  printFailedTests  =========='.blue.bold);
       printFailedTests(result, console);
+      console.log();
+      console.log('==========  printFailedTests with stacktrace  =========='.blue.bold);
+      printFailedTests(result, console, true);
     }
   })
   .catch((ex) => {

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -23,9 +23,6 @@ runQunitPuppeteer(qunitArgs)
       console.log();
       console.log('==========  printFailedTests  =========='.blue.bold);
       printFailedTests(result, console);
-      console.log();
-      console.log('==========  printFailedTests with stacktrace  =========='.blue.bold);
-      printFailedTests(result, console, true);
     }
   })
   .catch((ex) => {


### PR DESCRIPTION
This pull request adds a new parameter to the `printTestLog`/`printFailedTests` function to either show or hide the JavaScript stacktrace in the console.
The parameter defaults to `false` so we do not break any productive code and stay backward compatible:

##### Without stacktrace:
```javascript
printFailedTests(result, console);
```
![image](https://user-images.githubusercontent.com/5406078/55552250-334dab00-56dd-11e9-9b17-5cc72b2982af.png)

##### With stacktrace:
```javascript
printFailedTests(result, console, true);
```
![image](https://user-images.githubusercontent.com/5406078/55552265-3b0d4f80-56dd-11e9-81db-2c7bb63b14c8.png)

