### PR TITLE
Added override for qunit timeout since it cannot be catched. Also add…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,20 @@ node-qunit-puppeteer <URL> [<timeout>] [<puppeteerArgs>]
 - `<timeout>` - (optional) test run timeout in milliseconds. Default is 30000.
 - `<puppeteerArgs>` - (optional) Chrome command-line arguments. Default is "--allow-file-access-from-files".
 
+#### Chrome headless
+
+Defaults to 'old', as that was the previous behaviour in chrome.
+
+To toggle use `--headless=new` flag, add `--chrome-headless-new` to cli arguments.
+or `chromeHeadlessNew: true` to qunitArgs.
+
 #### Examples
 
 `node-qunit-puppeteer https://example.org/ 10000 "--allow-file-access-from-files --no-sandbox"`
 
 `node-qunit-puppeteer ./test/test-runner.html 10000 "--allow-file-access-from-files --no-sandbox"`
+
+`node-qunit-puppeteer ./test/test-runner.html 10000 "--chrome-headless-new"`
 
 ### Node module
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const colors = require('colors');
 
 const DEFAULT_QUNIT_TIMEOUT = 30000;
 const DEFAULT_PUPPETEER_TIMEOUT = 30000;
+const CHROME_HEADLESS_OLD = 'old';
+const CHROME_HEADLESS_NEW = 'new';
 const CALLBACKS_PREFIX = 'qunit_puppeteer_runner';
 const MODULE_START_CB = `${CALLBACKS_PREFIX}_moduleStart`;
 const MODULE_DONE_CB = `${CALLBACKS_PREFIX}_moduleDone`;
@@ -368,9 +370,21 @@ async function runQunitPuppeteer(qunitPuppeteerArgs) {
   const puppeteerArgs = qunitPuppeteerArgs.puppeteerArgs || ['--allow-file-access-from-files'];
   // puppeteer browser launch timeout
   const puppeteerTimeout =  qunitPuppeteerArgs.puppeteerTimeout || DEFAULT_PUPPETEER_TIMEOUT
+  //Chrome handle headless flag, default to old to not break current behaviour
+  let chromeHeadless = CHROME_HEADLESS_OLD;
+  const chromeHeadlessNewArg = puppeteerArgs.indexOf('--chrome-headless-new');
+  if(chromeHeadlessNewArg !== -1) {
+    chromeHeadless = CHROME_HEADLESS_NEW;
+    puppeteerArgs.splice(chromeHeadlessNewArg, 1);
+  } else {
+    if(qunitPuppeteerArgs.chromeHeadlessNew === true) {
+        chromeHeadless = CHROME_HEADLESS_NEW;
+    }
+  }
 
   const args = {
     args: puppeteerArgs,
+    headless: chromeHeadless,
     timeout: puppeteerTimeout,
   };
   const browser = await puppeteer.launch(args);


### PR DESCRIPTION
…ed ability to change timeout for loading a page in headless by passing additional argument too puppeteer.

I'm not that great with NodeJS so there is probably smarter  ways to do this. However

I wanted to change two things, in order to be able to run qunit with retries if anything fails.
* Opt out of the qunit setTimeout. Because it can not be catched if the promise was rejected or anything else fails before it was cleared.(puppeteer not being able to load page for example)
* Sometimes the launch or page-load in puppeteer/chrome times out (after 30 seconds default) which I wanted to be able to control this to retry faster.

Added working example in readme on how I use the changes to accomplish retries.