### PR TITLE
Hide puppeteer warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,7 +355,7 @@ async function runQunitWithBrowser(browser, qunitPuppeteerArgs) {
  */
 async function runQunitPuppeteer(qunitPuppeteerArgs) {
   const puppeteerArgs = qunitPuppeteerArgs.puppeteerArgs || ['--allow-file-access-from-files'];
-  const args = { args: puppeteerArgs, headless: 'old' };
+  const args = { args: puppeteerArgs, headless: 'new' };
   const browser = await puppeteer.launch(args);
 
   try {


### PR DESCRIPTION
Puppeteer reports warning

✔️ Expected result
No errors, or warnings

❌ Actual result
  Puppeteer old Headless deprecation warning:
    In the near feature `headless: true` will default to the new Headless mode
    for Chrome instead of the old Headless implementation. For more
    information, please see https://developer.chrome.com/articles/new-headless/.
    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`
    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.